### PR TITLE
Add `prerequisites` and sort shared steps with a graph

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,13 @@ authors = ["Junyuan Chen <norman.chen.git@gmail.com>"]
 version = "0.1.0"
 
 [deps]
-Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-Combinatorics = "1"
+Graphs = "1.4"
 MacroTools = "0.5"
-julia = "1.1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/StatsProcedures.jl
+++ b/src/StatsProcedures.jl
@@ -275,9 +275,9 @@ Steps are sorted based on dependencies specified with [`prerequisites`](@ref).
 function pool(ps::Vector{AbstractStatsProcedure})
     nps = length(ps)
     nps == 0 && return PooledStatsProcedure(ps, SharedStatsStep[])
-    nps == 1 && return PooledStatsProcedure(ps, [SharedStatsStep(s, [1]) for s in ps[1]])
     Nall = sum(length, ps)
     Nall == 0 && return PooledStatsProcedure(ps, SharedStatsStep[])
+    nps == 1 && return PooledStatsProcedure(ps, [SharedStatsStep(s, [1]) for s in ps[1]])
     nv = 0
     steps = SharedStatsStep[]
     lookup = Dict{StatsStep, Int}()

--- a/src/StatsProcedures.jl
+++ b/src/StatsProcedures.jl
@@ -44,7 +44,6 @@ in case both are specified.
 struct StatsStep{Alias, F<:Function, ById} end
 
 _f(::StatsStep{A,F}) where {A,F} = F.instance
-_byid(::StatsStep{A,F,I}) where {A,F,I} = I
 
 """
     required(s::StatsStep)
@@ -438,6 +437,13 @@ end
 function _count!(objcount::AbstractDict, obj)
     count = get(objcount, obj, 0)
     objcount[obj] = count + 1
+end
+
+if VERSION == v"1.0"
+    function Base.get!(f::Function, dict::IdDict, key)
+        out = get(dict, key, nothing)
+        return out === nothing ? f() : out
+    end
 end
 
 """

--- a/src/StatsProcedures.jl
+++ b/src/StatsProcedures.jl
@@ -17,7 +17,7 @@ export StatsStep,
 if VERSION < v"1.1-DEV"
     function Base.get!(default::Base.Callable, d::IdDict{K,V}, @nospecialize(key)) where {K, V}
         val = get(d, key, Base.secret_table_token)
-        return val === Base.secret_table_token ? setindex!(d, default(), key) : val
+        return val === Base.secret_table_token ? (d[key] = default()) : val
     end
 end
 

--- a/src/StatsProcedures.jl
+++ b/src/StatsProcedures.jl
@@ -443,9 +443,13 @@ function _count!(objcount::AbstractDict, obj)
 end
 
 if VERSION < v"1.1-DEV"
-    function Base.get!(f::Type, dict::IdDict, key)
-        val = get(dict, key, nothing)
-        return val === nothing ? (dict[key] = f()) : val
+    function Base.get!(default::Base.Callable, d::IdDict{K,V}, @nospecialize(key)) where {K, V}
+        val = get(d, key, Base.secret_table_token)
+        if val === Base.secret_table_token
+            val = default()
+            setindex!(d, val, key)
+        end
+        return val
     end
 end
 

--- a/src/StatsProcedures.jl
+++ b/src/StatsProcedures.jl
@@ -445,7 +445,7 @@ end
 if VERSION < v"1.1-DEV"
     function Base.get!(f::Type, dict::IdDict, key)
         val = get(dict, key, nothing)
-        return out === nothing ? (dict[key] = f()) : val
+        return val === nothing ? (dict[key] = f()) : val
     end
 end
 


### PR DESCRIPTION
Julia v1.0 is supported. The `verbose` option now additionally accepts an `IO` stream.